### PR TITLE
Add support for linked schedules for Valid Zipcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It is a single page app in React with a serverless backend currently being serve
 
 ### Setup Overview
 
-1. Request access to this repo, Airtable, and Netlify
+1. Request access to this repo, Airtable, SendGrid, and Netlify
 2. [Add API keys](#api-keys-and-env) to your local `.env` file
 3. Run `yarn`, `yarn start`, and `yarn start:api` to [install dependencies and start the app](#running-the-app)
 
@@ -25,6 +25,8 @@ Create an Airtable account and copy your personal API key at https://airtable.co
 To get a base ID, go to https://airtable.com/api and click on any USDR Food base e.g. Storefront Demo.
 
 The app ID begins with `app`. You can either grab the ID from the url `https://airtable.com/[some_key_beginning_with_app]/api/` or it will be displayed in the Introduction section: `The ID of this base is [some_key_beginning_with_app].`
+
+*Note: It is recommended that you clone the Storefront Demo base and use this copy while developing. This way you can test schema changes without worrying about breaking other instances of the app.*
 
 #### 2. Get Stripe API keys
 
@@ -88,6 +90,26 @@ yarn build
 Builds a minified and optimized version of the app for production to the `build` folder. **Your app is ready to be deployed!**
 
 See the section about [deployment](#setting-up-netlify-deploying-a-site) or [Create React App's docs](https://create-react-app.dev/docs/deployment) for more information.
+
+### Sending Emails in Dev
+
+Ask someone on the team for an invitation to the team SendGrid account. Once you have access:
+
+#### 1. Set the SendGrid API key
+
+You can grab the API key at https://app.sendgrid.com/settings/api_keys or have someone send it to you.
+
+Add the SendGrid API key to your `.env` file:
+
+```
+SENDGRID_API_KEY=
+```
+
+#### 2. Set the `email_from_address` field in Airtable
+
+In the `Config` table of your Airtable base, set the `email_from_address` to `storefront@usdigitalresponse.org`.
+
+Restart the app. You should now be able to receive emails sent by the app (e.g. order confirmation email).
 
 ## Setting up Netlify
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,8 +18,8 @@ import MuiThemeWrapper from './components/MuiThemeWrapper';
 import NotFoundPage from './pages/NotFoundPage';
 import ProductPage from './pages/ProductPage';
 import ProductsPage from './pages/ProductsPage';
-import SchemaPage from './pages/SchemaPage';
 import React from 'react';
+import SchemaPage from './pages/SchemaPage';
 
 const store = configureStore();
 AirtableService.init(store);

--- a/src/api-services/getEmailBody.js
+++ b/src/api-services/getEmailBody.js
@@ -28,11 +28,10 @@ export function getEmailBody(order) {
       if (isDelivery && order.address_zip) {
         const validZipcodeRecords = await fetchTable('Valid Zipcodes', {
           view: DEFAULT_VIEW,
-          fields: ['Linked Schedules'],
-          filterByFormula: `AND({Zip Code} = "${order.address_zip}", NOT({Linked Schedules} = BLANK()))`,
+          filterByFormula: `{Zip Code} = "${order.address_zip}"`,
         });
 
-        if (validZipcodeRecords.length > 0) {
+        if (validZipcodeRecords.length > 0 && validZipcodeRecords[0].fields['Linked Schedules']) {
           const zipcodeRecordLookup = validZipcodeRecords[0].fields['Linked Schedules']
             .map((schedule) => `RECORD_ID() = "${schedule}"`)
             .join(', ');

--- a/src/api-services/getEmailBody.js
+++ b/src/api-services/getEmailBody.js
@@ -24,13 +24,44 @@ export function getEmailBody(order) {
       const isDelivery = order['Type'] === 'Delivery';
       const pickupLocationName = order.pickupName;
 
+      let deliverySchedule = '';
+      if (isDelivery && order.address_zip) {
+        const validZipcodeRecords = await fetchTable('Valid Zipcodes', {
+          view: DEFAULT_VIEW,
+          fields: ['Linked Schedules'],
+          filterByFormula: `AND({Zip Code} = "${order.address_zip}", NOT({Linked Schedules} = BLANK()))`,
+        });
+
+        if (validZipcodeRecords.length > 0) {
+          const zipcodeRecordLookup = validZipcodeRecords[0].fields['Linked Schedules']
+            .map((schedule) => `RECORD_ID() = "${schedule}"`)
+            .join(', ');
+
+          const schedulesRecords = await fetchTable('Schedules', {
+            view: DEFAULT_VIEW,
+            fields: ['Start Time', 'End Time', 'Day'],
+            filterByFormula: `OR(${zipcodeRecordLookup})`,
+          });
+
+          deliverySchedule = schedulesRecords
+            .map((row) => {
+              return `${row.fields['Day']}s from ${row.fields['Start Time']} to ${row.fields['End Time']}`;
+            })
+            .join(', ');
+        }
+      }
+
       const orderDetails = `
         <p style="margin-top: 0px;"></p>
         <b>${isDelivery ? 'Delivery Address' : 'Pickup Location'}:</b>
         <p style="white-space: pre-wrap; margin-top: 0px;">${
           isDelivery ? order['Delivery Address'] : order.pickupAddress
         }</p>
-        <b>Items ordered:</b>
+        ${deliverySchedule &&
+          `<p style="margin-top: 0px;"></p>
+            <b>Delivery Schedule:</b>
+            <p style="white-space: pre-wrap; margin-top: 0px;">${deliverySchedule}</p>`}
+        <b>Items Ordered:</b>
         ${orderItemList}
         ${orderAmount}
         `;

--- a/src/api/get-cms.js
+++ b/src/api/get-cms.js
@@ -69,7 +69,6 @@ exports.handler = async (event, context) => {
     const schedules = schedulesRecords.map((row) => {
       return {
         id: row.id,
-        type: row.fields['Type'],
         start: row.fields['Start Time'],
         end: row.fields['End Time'],
         day: row.fields['Day'],
@@ -79,7 +78,10 @@ exports.handler = async (event, context) => {
     // Valid Zipcodes
     const validZipcodesRecords = await fetchTable('Valid Zipcodes', { view: DEFAULT_VIEW });
     const validZipcodes = validZipcodesRecords.map((row) => {
-      return row.fields['Zip Code'];
+      return {
+        zipcode: row.fields['Zip Code'],
+        schedules: row.fields['Linked Schedules']
+      }
     });
 
     // Questions

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -245,6 +245,14 @@ export interface IStockZipcodes {
   stockRemaining: number;
 }
 
+export interface IValidZipcode {
+  zipcode: string;
+  schedules?: string[];
+  resolvedSchedules?: ISchedule[];
+}
+
+export type ZipcodeScheduleMap = Record<string, ISchedule[]>;
+
 export function isSchedule(schedule?: string | ISchedule): schedule is ISchedule {
   return !!schedule && (schedule as ISchedule).id !== undefined;
 }
@@ -253,7 +261,6 @@ export type Day = 'Monday' | 'Tuesday' | 'Wednesday' | 'Thursday' | 'Friday' | '
 
 export interface ISchedule {
   id: string;
-  type: OrderType;
   start: string;
   end: string;
   day: Day;

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -248,7 +248,6 @@ export interface IStockZipcodes {
 export interface IValidZipcode {
   zipcode: string;
   schedules?: string[];
-  resolvedSchedules?: ISchedule[];
 }
 
 export type ZipcodeScheduleMap = Record<string, ISchedule[]>;

--- a/src/components/OrderTypeSelector.tsx
+++ b/src/components/OrderTypeSelector.tsx
@@ -2,7 +2,7 @@ import { Button, Card, CardActionArea, CardActions, Grid, Typography } from '@ma
 import { IAppState } from '../store/app';
 import { IConfig, IPickupLocation, OrderType } from '../common/types';
 import { SetLocationsDialogIsOpen, SetOrderType, selectedLocationSelector } from '../store/cart';
-import { pickupLocationsSelector, validZipcodesSelector } from '../store/cms';
+import { pickupLocationsSelector, zipcodeListSelector } from '../store/cms';
 import { useDispatch, useSelector } from 'react-redux';
 import { useIsSmall } from '../common/hooks';
 import CheckedIcon from '@material-ui/icons/CheckBox';
@@ -24,7 +24,7 @@ const OrderTypeSelector: React.FC<Props> = ({ className }) => {
   const pickupLocationCount = useSelector<IAppState, IPickupLocation[]>(pickupLocationsSelector).length;
   const orderType = useSelector<IAppState, OrderType>((state) => state.cart.orderType);
   const config = useSelector<IAppState, IConfig>((state) => state.cms.config);
-  const validZipcodes = useSelector<IAppState, string[]>(validZipcodesSelector);
+  const zipcodeList = useSelector<IAppState, string[]>(zipcodeListSelector);
   const { deliveryEnabled, pickupEnabled, stockByLocation } = config;
 
   return (
@@ -47,7 +47,7 @@ const OrderTypeSelector: React.FC<Props> = ({ className }) => {
                   </Typography>
                   <Typography variant="body1" className={styles.description}>
                     <Content id="delivery_option_subtitle" defaultText="Credit / Debit Card Only" />
-                    {stockByLocation && <span> Only valid for {validZipcodes.join(', ')}.</span>}
+                    {stockByLocation && <span> Only valid for {zipcodeList.join(', ')}.</span>}
                   </Typography>
                 </div>
               </div>

--- a/src/components/ZipCodeField.module.scss
+++ b/src/components/ZipCodeField.module.scss
@@ -1,0 +1,6 @@
+@import '../common/variables';
+
+
+.note {
+  opacity: 0.5;
+}

--- a/src/components/ZipCodeField.tsx
+++ b/src/components/ZipCodeField.tsx
@@ -28,14 +28,14 @@ const ZipCodeField: React.FC<TextFieldProps> = (props) => {
         className={props.className}
         renderInput={(params) => <TextField {...props} {...params} />}
       />
-      {zipcodeSchedules[selectedZipcode] && zipcodeSchedules[selectedZipcode].length && (
+      {zipcodeSchedules[selectedZipcode] && zipcodeSchedules[selectedZipcode].length > 0 ? (
         <>
           <Typography variant="body2" className={styles.note}>
             <Content id="zipcode_delivery_schedule_label" defaultText="Delivery is available for this zipcode" />
           </Typography>
           <ScheduleView variant="body2" schedules={zipcodeSchedules[selectedZipcode]} className={styles.note} />
         </>
-      )}
+      ) : null}
     </>
   );
 };

--- a/src/components/ZipCodeField.tsx
+++ b/src/components/ZipCodeField.tsx
@@ -13,6 +13,9 @@ const ZipCodeField: React.FC<TextFieldProps> = (props) => {
   const zipcodeList = useSelector<IAppState, string[]>(zipcodeListSelector);
   const zipcodeSchedules = useSelector<IAppState, ZipcodeScheduleMap>(zipcodeSchedulesSelector);
 
+  // We should be using react-hook-form's watch('zip') instead of `useState` to control the zip code value
+  // but it causes a bug that prevents users from typing in the TextField. Leaving it like this for now.
+  //
   // Material UI Autocomplete throws a warning if passed an empty string; its empty state is null
   const [selectedZipcode, setSelectedZipcode] = useState<string | null>(null);
 

--- a/src/components/ZipCodeField.tsx
+++ b/src/components/ZipCodeField.tsx
@@ -1,21 +1,34 @@
 import { Autocomplete } from '@material-ui/lab';
 import { IAppState } from '../store/app';
 import { TextField, TextFieldProps } from '@material-ui/core';
+import { ZipcodeScheduleMap } from '../common/types';
 import { useSelector } from 'react-redux';
-import { validZipcodesSelector } from '../store/cms';
-import React from 'react';
+import { zipcodeListSelector, zipcodeSchedulesSelector } from '../store/cms';
+import React, { ChangeEvent, useState } from 'react';
+import ScheduleView from './ScheduleView';
 
 const ZipCodeField: React.FC<TextFieldProps> = (props) => {
-  const validZipcodes = useSelector<IAppState, string[]>(validZipcodesSelector);
+  const zipcodeList = useSelector<IAppState, string[]>(zipcodeListSelector);
+  const zipcodeSchedules = useSelector<IAppState, ZipcodeScheduleMap>(zipcodeSchedulesSelector);
 
-  return validZipcodes.length === 0 ? (
+  const [selectedZipcode, setSelectedZipcode] = useState<string>('');
+
+  return zipcodeList.length === 0 ? (
     <TextField {...props} />
   ) : (
-    <Autocomplete
-      options={validZipcodes}
-      className={props.className}
-      renderInput={(params) => <TextField {...props} {...params} />}
-    />
+    <>
+      <Autocomplete
+        value={selectedZipcode}
+        onChange={(e: ChangeEvent<any>, value: string | null) => {
+          setSelectedZipcode(value || '');
+        }}
+        options={zipcodeList}
+        className={props.className}
+        renderInput={(params) => <TextField {...props} {...params} />}
+      />
+
+      <ScheduleView variant="body2" schedules={zipcodeSchedules[selectedZipcode]} />
+    </>
   );
 };
 

--- a/src/components/ZipCodeField.tsx
+++ b/src/components/ZipCodeField.tsx
@@ -31,7 +31,7 @@ const ZipCodeField: React.FC<TextFieldProps> = (props) => {
       {zipcodeSchedules[selectedZipcode] && zipcodeSchedules[selectedZipcode].length > 0 ? (
         <>
           <Typography variant="body2" className={styles.note}>
-            <Content id="zipcode_delivery_schedule_label" defaultText="Delivery is available for this zipcode" />
+            <Content id="zipcode_delivery_schedule_label" defaultText="Delivery to this zip code has the following schedule:" />
           </Typography>
           <ScheduleView variant="body2" schedules={zipcodeSchedules[selectedZipcode]} className={styles.note} />
         </>

--- a/src/components/ZipCodeField.tsx
+++ b/src/components/ZipCodeField.tsx
@@ -13,7 +13,8 @@ const ZipCodeField: React.FC<TextFieldProps> = (props) => {
   const zipcodeList = useSelector<IAppState, string[]>(zipcodeListSelector);
   const zipcodeSchedules = useSelector<IAppState, ZipcodeScheduleMap>(zipcodeSchedulesSelector);
 
-  const [selectedZipcode, setSelectedZipcode] = useState<string>('');
+  // Material UI Autocomplete throws a warning if passed an empty string; its empty state is null
+  const [selectedZipcode, setSelectedZipcode] = useState<string | null>(null);
 
   return zipcodeList.length === 0 ? (
     <TextField {...props} />
@@ -28,10 +29,13 @@ const ZipCodeField: React.FC<TextFieldProps> = (props) => {
         className={props.className}
         renderInput={(params) => <TextField {...props} {...params} />}
       />
-      {zipcodeSchedules[selectedZipcode] && zipcodeSchedules[selectedZipcode].length > 0 ? (
+      {selectedZipcode && zipcodeSchedules[selectedZipcode] && zipcodeSchedules[selectedZipcode].length > 0 ? (
         <>
           <Typography variant="body2" className={styles.note}>
-            <Content id="zipcode_delivery_schedule_label" defaultText="Delivery to this zip code has the following schedule:" />
+            <Content
+              id="zipcode_delivery_schedule_label"
+              defaultText="Delivery to this zip code has the following schedule:"
+            />
           </Typography>
           <ScheduleView variant="body2" schedules={zipcodeSchedules[selectedZipcode]} className={styles.note} />
         </>

--- a/src/components/ZipCodeField.tsx
+++ b/src/components/ZipCodeField.tsx
@@ -1,11 +1,13 @@
 import { Autocomplete } from '@material-ui/lab';
 import { IAppState } from '../store/app';
-import { TextField, TextFieldProps } from '@material-ui/core';
+import { TextField, TextFieldProps, Typography } from '@material-ui/core';
 import { ZipcodeScheduleMap } from '../common/types';
 import { useSelector } from 'react-redux';
 import { zipcodeListSelector, zipcodeSchedulesSelector } from '../store/cms';
+import Content from './Content';
 import React, { ChangeEvent, useState } from 'react';
 import ScheduleView from './ScheduleView';
+import styles from './ZipCodeField.module.scss';
 
 const ZipCodeField: React.FC<TextFieldProps> = (props) => {
   const zipcodeList = useSelector<IAppState, string[]>(zipcodeListSelector);
@@ -26,8 +28,14 @@ const ZipCodeField: React.FC<TextFieldProps> = (props) => {
         className={props.className}
         renderInput={(params) => <TextField {...props} {...params} />}
       />
-
-      <ScheduleView variant="body2" schedules={zipcodeSchedules[selectedZipcode]} />
+      {zipcodeSchedules[selectedZipcode] && zipcodeSchedules[selectedZipcode].length && (
+        <>
+          <Typography variant="body2" className={styles.note}>
+            <Content id="zipcode_delivery_schedule_label" defaultText="Delivery is available for this zipcode" />
+          </Typography>
+          <ScheduleView variant="body2" schedules={zipcodeSchedules[selectedZipcode]} className={styles.note} />
+        </>
+      )}
     </>
   );
 };

--- a/src/pages/ConfirmationPage.tsx
+++ b/src/pages/ConfirmationPage.tsx
@@ -5,11 +5,12 @@ import {
   IOrderSummary,
   IPickupLocation,
   OrderStatus,
+  ZipcodeScheduleMap,
   isDonationSummary,
   isOrderSummary,
 } from '../common/types';
 import { formatDate } from '../common/format';
-import { pickupLocationsSelector, useContent } from '../store/cms';
+import { pickupLocationsSelector, useContent, zipcodeSchedulesSelector } from '../store/cms';
 import { useIsSmall } from '../common/hooks';
 import { useSelector } from 'react-redux';
 import AddressView from '../components/AddressView';
@@ -33,6 +34,7 @@ const ConfirmationPage: React.FC<Props> = () => {
     useContent('confirmation_copy_all') || `We've sent an email confirmation to {customer-email}`;
   const confirmationCopyOrder = useContent('confirmation_copy_order');
   const pickupLocations = useSelector<IAppState, IPickupLocation[] | undefined>(pickupLocationsSelector);
+  const zipcodeSchedules = useSelector<IAppState, ZipcodeScheduleMap>(zipcodeSchedulesSelector);
   const pickupLocation =
     isOrderSummary(confirmation) && confirmation.pickupLocationId && pickupLocations
       ? pickupLocations.find((location) => location.id === confirmation.pickupLocationId)
@@ -123,6 +125,13 @@ const ConfirmationPage: React.FC<Props> = () => {
                     Delivery Address
                   </Typography>
                   <AddressView address={confirmation.deliveryAddress} />
+                  {zipcodeSchedules[confirmation.deliveryAddress?.zip] && (
+                    <ScheduleView
+                      variant="body2"
+                      schedules={zipcodeSchedules[confirmation.deliveryAddress.zip]}
+                      className={styles.schedules}
+                    />
+                  )}
                   {confirmation.deliveryPreferences && (
                     <div className={styles.preferences}>
                       {confirmation.deliveryPreferences.map((pref) => (

--- a/src/pages/SchemaPage.tsx
+++ b/src/pages/SchemaPage.tsx
@@ -1,6 +1,6 @@
 import BaseLayout from '../layouts/BaseLayout';
 import Loading from '../components/Loading';
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 const SchemaPage: React.FC = () => {
   const [loading, setLoading] = useState<boolean>(true);

--- a/src/store/cms.ts
+++ b/src/store/cms.ts
@@ -6,9 +6,11 @@ import {
   IOrderItem,
   IPickupLocation,
   ISchedule,
+  IValidZipcode,
   InventoryRecord,
   OrderType,
   Question,
+  ZipcodeScheduleMap,
 } from '../common/types';
 import { Stripe, loadStripe } from '@stripe/stripe-js';
 import { TypedAction, TypedReducer, setWith } from 'redoodle';
@@ -28,7 +30,7 @@ export interface ICmsState {
   };
   pickupLocations: IPickupLocation[];
   schedules: ISchedule[];
-  validZipcodes: string[];
+  validZipcodes: IValidZipcode[];
   questions: Question[];
 }
 
@@ -216,20 +218,41 @@ export const pickupLocationsSelector = Reselect.createSelector(
   },
 );
 
-export const validZipcodesSelector = Reselect.createSelector(
+export const zipcodeListSelector = Reselect.createSelector(
   (state: IAppState) => state.cms.validZipcodes,
   (state: IAppState) => state.cart.items,
   (state: IAppState) => state.cms.config.stockByLocation,
   productListSelector,
-  (validZipcodes: string[], cartItems: IOrderItem[], stockByLocation: boolean, productList: InventoryRecord[]) => {
+  (
+    validZipcodes: IValidZipcode[],
+    cartItems: IOrderItem[],
+    stockByLocation: boolean,
+    productList: InventoryRecord[],
+  ) => {
+    const zipcodes = validZipcodes.map((validZipcode: IValidZipcode) => validZipcode.zipcode);
+
     if (stockByLocation && cartItems.length === 1 && cartItems[0].quantity === 1) {
       const stockZipcodes = getProduct(cartItems[0].id, productList)?.zipcodes;
       return stockZipcodes
         ? stockZipcodes.reduce((acc, stockZipcode) => acc.concat(stockZipcode.zipcodes), [] as string[]).sort()
-        : validZipcodes.sort();
+        : zipcodes.sort();
     } else {
-      return validZipcodes.sort();
+      return zipcodes.sort();
     }
+  },
+);
+
+export const zipcodeSchedulesSelector = Reselect.createSelector(
+  (state: IAppState) => state.cms.validZipcodes,
+  (state: IAppState) => state.cms.schedules,
+  (validZipcodes: IValidZipcode[], schedules: ISchedule[]) => {
+    return validZipcodes.reduce((zipcodeSchedules: ZipcodeScheduleMap, validZipcode: IValidZipcode) => {
+      zipcodeSchedules[validZipcode.zipcode] = validZipcode.schedules
+        ? validZipcode.schedules.map((scheduleId: any) => schedules.find((s) => s.id === scheduleId)!)
+        : [];
+
+      return zipcodeSchedules;
+    }, {});
   },
 );
 


### PR DESCRIPTION
This adds a new `Linked Schedules` field to our `Valid Zipcode` data (now saved as type `IValidZipcode`) and displays it in our checkout form when a user enters a zipcode.

- Removed references to the `type` field in the Schedules table (https://usdrcovid19.slack.com/archives/C0125V91WAW/p1594918327164400)
- Made some minor naming updates for clarity (`zipcodeListSelector` instead of `validZipcodesSelector`, since `zipcodeListSelector` returns a list of strings and `validZipcodes` is now a more complex object)

**Questions**

- Do we still show "Delivery Preferences" if a zipcode has a set delivery schedule?
- What kind of copy should we have around the zipcode schedule? `Delivery is available for this zipcode: [schedule]` or something similar?

**Airtable schema changes**

- new field in `Valid Zipcodes` table: `Linked Schedules`, allows multiple values

![Screen Shot 2020-07-17 at 9 02 47 PM](https://user-images.githubusercontent.com/1165936/87844327-fde8b480-c870-11ea-9aa0-310f68d6308b.png)

**Screen capture**

![Jul-17-2020 21-01-21](https://user-images.githubusercontent.com/1165936/87844300-bc580980-c870-11ea-8c48-e5b49c36950b.gif)
![Screen Shot 2020-07-21 at 10 46 23 AM](https://user-images.githubusercontent.com/1165936/88117236-6f757b00-cb6f-11ea-8066-b4ec78f749f5.png)
![Screen Shot 2020-07-21 at 4 30 58 PM](https://user-images.githubusercontent.com/1165936/88117293-96cc4800-cb6f-11ea-89a0-a432adb97bae.png)

