### PR TITLE
Fix empty ValidZipcodes row issue

### DIFF
--- a/src/api/get-cms.js
+++ b/src/api/get-cms.js
@@ -77,12 +77,14 @@ exports.handler = async (event, context) => {
 
     // Valid Zipcodes
     const validZipcodesRecords = await fetchTable('Valid Zipcodes', { view: DEFAULT_VIEW });
-    const validZipcodes = validZipcodesRecords.map((row) => {
-      return {
-        zipcode: row.fields['Zip Code'],
-        schedules: row.fields['Linked Schedules']
-      }
-    });
+    const validZipcodes = validZipcodesRecords
+      .filter((row) => row.fields['Zip Code'])
+      .map((row) => {
+        return {
+          zipcode: row.fields['Zip Code'],
+          schedules: row.fields['Linked Schedules']
+        }
+      });
 
     // Questions
     const questionsRecords = await fetchTable('Questions', { view: DEFAULT_VIEW });

--- a/src/components/DiscountCode.tsx
+++ b/src/components/DiscountCode.tsx
@@ -5,10 +5,10 @@ import { IDiscountCode } from '../common/types';
 import { SetDiscountCode } from '../store/checkout';
 import { useDispatch, useSelector } from 'react-redux';
 import ArrowIcon from '@material-ui/icons/ArrowForward';
+import Content from './Content';
 import React, { useState } from 'react';
 import classNames from 'classnames';
 import styles from './DiscountCode.module.scss';
-import Content from "./Content";
 
 interface Props {
   className?: string;
@@ -39,9 +39,11 @@ const DiscountCode: React.FC<Props> = ({ className }) => {
 
   return (
     <div className={classNames(styles.container, className)}>
-      {!show && <Link onClick={() => setShow(true)}>
-        <Content id="discount_code_label" defaultText="I have a discount code"/>
-      </Link>}
+      {!show && (
+        <Link onClick={() => setShow(true)}>
+          <Content id="discount_code_label" defaultText="I have a discount code" />
+        </Link>
+      )}
       {show && (
         <TextField
           fullWidth

--- a/src/store/cms.ts
+++ b/src/store/cms.ts
@@ -230,7 +230,10 @@ export const zipcodeListSelector = Reselect.createSelector(
     stockByLocation: boolean,
     productList: InventoryRecord[],
   ) => {
-    const zipcodes = validZipcodes.map((validZipcode: IValidZipcode) => validZipcode.zipcode);
+    const zipcodes = validZipcodes
+      // Prevent undefined zipcode values
+      .filter((validZipcode: IValidZipcode) => validZipcode.zipcode)
+      .map((validZipcode: IValidZipcode) => validZipcode.zipcode);
 
     if (stockByLocation && cartItems.length === 1 && cartItems[0].quantity === 1) {
       const stockZipcodes = getProduct(cartItems[0].id, productList)?.zipcodes;

--- a/src/store/cms.ts
+++ b/src/store/cms.ts
@@ -250,13 +250,15 @@ export const zipcodeSchedulesSelector = Reselect.createSelector(
   (state: IAppState) => state.cms.validZipcodes,
   (state: IAppState) => state.cms.schedules,
   (validZipcodes: IValidZipcode[], schedules: ISchedule[]) => {
-    return validZipcodes.reduce((zipcodeSchedules: ZipcodeScheduleMap, validZipcode: IValidZipcode) => {
-      zipcodeSchedules[validZipcode.zipcode] = validZipcode.schedules
-        ? validZipcode.schedules.map((scheduleId: any) => schedules.find((s) => s.id === scheduleId)!)
-        : [];
+    return validZipcodes
+      .filter((validZipcode: IValidZipcode) => validZipcode.zipcode)
+      .reduce((zipcodeSchedules: ZipcodeScheduleMap, validZipcode: IValidZipcode) => {
+        zipcodeSchedules[validZipcode.zipcode] = validZipcode.schedules
+          ? validZipcode.schedules.map((scheduleId: any) => schedules.find((s) => s.id === scheduleId)!)
+          : [];
 
-      return zipcodeSchedules;
-    }, {});
+        return zipcodeSchedules;
+      }, {});
   },
 );
 

--- a/src/store/cms.ts
+++ b/src/store/cms.ts
@@ -230,10 +230,7 @@ export const zipcodeListSelector = Reselect.createSelector(
     stockByLocation: boolean,
     productList: InventoryRecord[],
   ) => {
-    const zipcodes = validZipcodes
-      // Prevent undefined zipcode values
-      .filter((validZipcode: IValidZipcode) => validZipcode.zipcode)
-      .map((validZipcode: IValidZipcode) => validZipcode.zipcode);
+    const zipcodes = validZipcodes.map((validZipcode: IValidZipcode) => validZipcode.zipcode);
 
     if (stockByLocation && cartItems.length === 1 && cartItems[0].quantity === 1) {
       const stockZipcodes = getProduct(cartItems[0].id, productList)?.zipcodes;
@@ -250,15 +247,13 @@ export const zipcodeSchedulesSelector = Reselect.createSelector(
   (state: IAppState) => state.cms.validZipcodes,
   (state: IAppState) => state.cms.schedules,
   (validZipcodes: IValidZipcode[], schedules: ISchedule[]) => {
-    return validZipcodes
-      .filter((validZipcode: IValidZipcode) => validZipcode.zipcode)
-      .reduce((zipcodeSchedules: ZipcodeScheduleMap, validZipcode: IValidZipcode) => {
-        zipcodeSchedules[validZipcode.zipcode] = validZipcode.schedules
-          ? validZipcode.schedules.map((scheduleId: any) => schedules.find((s) => s.id === scheduleId)!)
-          : [];
+    return validZipcodes.reduce((zipcodeSchedules: ZipcodeScheduleMap, validZipcode: IValidZipcode) => {
+      zipcodeSchedules[validZipcode.zipcode] = validZipcode.schedules
+        ? validZipcode.schedules.map((scheduleId: any) => schedules.find((s) => s.id === scheduleId)!)
+        : [];
 
-        return zipcodeSchedules;
-      }, {});
+      return zipcodeSchedules;
+    }, {});
   },
 );
 


### PR DESCRIPTION
Filters out `undefined` values from `zipcodeListSelector` to prevent ZipCode Autocomplete from breaking when there are empty `Valid Zipcodes` rows

**STRs**:
- Create an empty row in the `Valid Zipcodes` table
- On the cart page, verify that `Delivery` section doesn't show an empty `, .` where a zipcode should be
- On the checkout page, verify that clicking the zipcode field shows the list of zipcodes instead of crashing the app