### PR TITLE
Update `requiresPayment` selector to `false` if no main stripe key is set

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -20,6 +20,7 @@ export interface IConfig {
   embeddedViewId: string;
   embeddedViewName?: string;
   stockByLocation: boolean;
+  stripeAPIKeyMain?: string;
 }
 
 export interface IContentRecord extends Record<string, string | AirtableImage[]> {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -21,6 +21,7 @@ export interface IConfig {
   embeddedViewName?: string;
   stockByLocation: boolean;
   stripeAPIKeyMain?: string;
+  stripeAPIKeyDonation?: string;
 }
 
 export interface IContentRecord extends Record<string, string | AirtableImage[]> {

--- a/src/components/OrderTypeSelector.tsx
+++ b/src/components/OrderTypeSelector.tsx
@@ -46,7 +46,7 @@ const OrderTypeSelector: React.FC<Props> = ({ className }) => {
                     <Content id="delivery_option_title" defaultText="Delivery" />
                   </Typography>
                   <Typography variant="body1" className={styles.description}>
-                    <Content id="delivery_option_subtitle" defaultText="Credit / Debit Card Only" />
+                    <Content id="delivery_option_subtitle" defaultText="Credit / Debit Card" />
                     {stockByLocation && <span> Only valid for {zipcodeList.join(', ')}.</span>}
                   </Typography>
                 </div>

--- a/src/pages/CheckoutPage.tsx
+++ b/src/pages/CheckoutPage.tsx
@@ -36,6 +36,7 @@ import {
 } from '../store/checkout';
 import { SetLocationsDialogIsOpen, selectedLocationSelector } from '../store/cart';
 import { StripeService } from '../services/StripeService';
+import { Stripe, StripeElements } from '@stripe/stripe-js';
 import { questionsSelector, useContent } from '../store/cms';
 import { reverse } from '../common/router';
 import { useDispatch, useSelector } from 'react-redux';
@@ -64,7 +65,12 @@ import classNames from 'classnames';
 import qs from 'qs';
 import styles from './CheckoutPage.module.scss';
 
-function CheckoutPageMain() {
+interface Props {
+  stripe?: Stripe | null;
+  elements?: StripeElements | null;
+}
+
+const CheckoutPageMain: React.FC<Props> = ({ stripe = null, elements = null }) => {
   const { register, watch, handleSubmit, errors, clearError } = useForm<ICheckoutFormData>();
   const config = useSelector<IAppState, IConfig>((state) => state.cms.config);
   const {
@@ -78,8 +84,6 @@ function CheckoutPageMain() {
   const orderType = useSelector<IAppState, OrderType>((state) => state.cart.orderType);
   const isSmall = useIsSmall();
   const hasErrors = Object.keys(errors).length > 0;
-  const stripe = useStripe();
-  const elements = useElements();
   const items = useSelector<IAppState, IOrderItem[]>((state) => state.cart.items);
   const paymentStatus = useSelector<IAppState, PaymentStatus>(paymentStatusSelector);
   const paymentError = useSelector<IAppState, string | undefined>((state) => state.checkout.error);
@@ -332,12 +336,24 @@ function CheckoutPageMain() {
       </form>
     </BaseLayout>
   );
-}
+};
 
-export default function CheckoutPage() {
+// TODO: useStripe and useElement must be called in an Elements component, and
+// the Elements component doesn't work without a valid stripe promise...this was my
+// workaround but I imagine there's a better way to do this
+const CheckoutPageWithStripe = () => {
+  const stripe = useStripe();
+  const elements = useElements();
+
   return (
     <StripeElementsWrapper type="main">
-      <CheckoutPageMain />
+      <CheckoutPageMain stripe={stripe} elements={elements} />
     </StripeElementsWrapper>
   );
+};
+
+export default function CheckoutPage() {
+  const config = useSelector<IAppState, IConfig>((state) => state.cms.config);
+
+  return config.stripeAPIKeyMain ? <CheckoutPageWithStripe /> : <CheckoutPageMain />;
 }

--- a/src/pages/CheckoutPage.tsx
+++ b/src/pages/CheckoutPage.tsx
@@ -35,8 +35,8 @@ import {
   requiresPaymentSelector,
 } from '../store/checkout';
 import { SetLocationsDialogIsOpen, selectedLocationSelector } from '../store/cart';
-import { StripeService } from '../services/StripeService';
 import { Stripe, StripeElements } from '@stripe/stripe-js';
+import { StripeService } from '../services/StripeService';
 import { questionsSelector, useContent } from '../store/cms';
 import { reverse } from '../common/router';
 import { useDispatch, useSelector } from 'react-redux';
@@ -345,15 +345,17 @@ const CheckoutPageWithStripe = () => {
   const stripe = useStripe();
   const elements = useElements();
 
-  return (
-    <StripeElementsWrapper type="main">
-      <CheckoutPageMain stripe={stripe} elements={elements} />
-    </StripeElementsWrapper>
-  );
+  return <CheckoutPageMain stripe={stripe} elements={elements} />;
 };
 
 export default function CheckoutPage() {
   const config = useSelector<IAppState, IConfig>((state) => state.cms.config);
 
-  return config.stripeAPIKeyMain ? <CheckoutPageWithStripe /> : <CheckoutPageMain />;
+  return config.stripeAPIKeyMain ? (
+    <StripeElementsWrapper type="main">
+      <CheckoutPageWithStripe />
+    </StripeElementsWrapper>
+  ) : (
+    <CheckoutPageMain />
+  );
 }

--- a/src/services/AirtableService.ts
+++ b/src/services/AirtableService.ts
@@ -61,6 +61,7 @@ export class AirtableService {
             embeddedViewName: records.config.embedded_view_name,
             stockByLocation: records.config.stock_by_location === 'true' ? true : false,
             stripeAPIKeyMain: records.config.stripe_main_public_api_key,
+            stripeAPIKeyDonation: records.config.stripe_donation_public_api_key,
           }),
           SetOrderType.create(
             deliveryEnabled ? records.config.default_order_type || OrderType.DELIVERY : OrderType.PICKUP,
@@ -71,14 +72,26 @@ export class AirtableService {
           SetValidZipcodes.create(records.validZipcodes),
           SetQuestions.create(records.questions),
           SetPickupLocations.create(records.pickupLocations),
-          SetStripePromise.create({
-            main: records.config.stripe_main_public_api_key,
-            donation: records.config.stripe_donation_public_api_key,
-          }),
         ];
 
         if (records.pickupLocations.length === 1) {
           actions.push(SetSelectedLocation.create(records.pickupLocations[0].id));
+        }
+
+        if (typeof records.config.stripe_main_public_api_key === 'string') {
+          actions.push(
+            SetStripePromise.create({
+              main: records.config.stripe_main_public_api_key,
+            }),
+          );
+        }
+
+        if (typeof records.config.stripe_donation_public_api_key === 'string') {
+          actions.push(
+            SetStripePromise.create({
+              donation: records.config.stripe_donation_public_api_key,
+            }),
+          );
         }
 
         AirtableService.store.dispatch(CompoundAction(actions));

--- a/src/services/AirtableService.ts
+++ b/src/services/AirtableService.ts
@@ -60,6 +60,7 @@ export class AirtableService {
             embeddedViewId: records.config.embedded_view_id,
             embeddedViewName: records.config.embedded_view_name,
             stockByLocation: records.config.stock_by_location === 'true' ? true : false,
+            stripeAPIKeyMain: records.config.stripe_main_public_api_key,
           }),
           SetOrderType.create(
             deliveryEnabled ? records.config.default_order_type || OrderType.DELIVERY : OrderType.PICKUP,

--- a/src/services/StripeService.ts
+++ b/src/services/StripeService.ts
@@ -73,8 +73,6 @@ export class StripeService {
   }
 
   public static async pay(formData: ICheckoutFormData, stripe: Stripe | null, elements: StripeElements | null) {
-    if (!stripe || !elements) return;
-
     const state = StripeService.store.getState();
     const subtotal = subtotalSelector(state);
     const discount = discountSelector(state);
@@ -125,6 +123,11 @@ export class StripeService {
     // process payment
     let stripePaymentId: string | undefined;
     if (requiresPayment) {
+      if (!stripe || !elements) {
+        StripeService.store.dispatch(SetError.create('Stripe or elements object missing.'));
+        return PaymentStatus.FAILED;
+      }
+
       stripePaymentId = await StripeService.processPayment('main', total, stripe, elements);
       if (stripePaymentId) {
         orderIntent.status = OrderStatus.PAID;

--- a/src/store/checkout.ts
+++ b/src/store/checkout.ts
@@ -114,7 +114,7 @@ export const requiresPaymentSelector = Reselect.createSelector(
     isDonationRequest: boolean,
     payUponPickupEnabled: boolean,
     payState: PayState,
-    stripeAPIKeyMain?: string
+    stripeAPIKeyMain?: string,
   ) => {
     return (
       typeof stripeAPIKeyMain === 'string' &&

--- a/src/store/checkout.ts
+++ b/src/store/checkout.ts
@@ -107,14 +107,17 @@ export const requiresPaymentSelector = Reselect.createSelector(
   (state: IAppState) => state.checkout.isDonationRequest,
   (state: IAppState) => state.cms.config.payUponPickupEnabled,
   (state: IAppState) => state.checkout.payState,
+  (state: IAppState) => state.cms.config.stripeAPIKeyMain,
   (
     total: number,
     orderType: OrderType,
     isDonationRequest: boolean,
     payUponPickupEnabled: boolean,
     payState: PayState,
+    stripeAPIKeyMain?: string
   ) => {
     return (
+      typeof stripeAPIKeyMain === 'string' &&
       total > 0 &&
       (orderType === OrderType.DELIVERY || !payUponPickupEnabled) &&
       !isDonationRequest &&

--- a/src/store/cms.ts
+++ b/src/store/cms.ts
@@ -56,7 +56,13 @@ export const cmsReducer: any = TypedReducer.builder<ICmsState>()
   .withHandler(SetPickupLocations.TYPE, (state, pickupLocations) => setWith(state, { pickupLocations }))
   .withHandler(SetStripePromise.TYPE, (state, keys) =>
     setWith(state, {
-      stripeObjects: { main: loadStripe(keys.main), donation: loadStripe(keys.donation) },
+      stripeObjects: {
+        ...state.stripeObjects,
+        ...Object.keys(keys).reduce((stripeKeys: Record<string, Promise<Stripe | null> | null>, keyType: string) => {
+          stripeKeys[keyType] = loadStripe(keys[keyType])
+          return stripeKeys;
+        }, {})
+      }
     }),
   )
   .withHandler(SetLanguage.TYPE, (state, language) => setWith(state, { language }))

--- a/src/store/cms.ts
+++ b/src/store/cms.ts
@@ -59,10 +59,10 @@ export const cmsReducer: any = TypedReducer.builder<ICmsState>()
       stripeObjects: {
         ...state.stripeObjects,
         ...Object.keys(keys).reduce((stripeKeys: Record<string, Promise<Stripe | null> | null>, keyType: string) => {
-          stripeKeys[keyType] = loadStripe(keys[keyType])
+          stripeKeys[keyType] = loadStripe(keys[keyType]);
           return stripeKeys;
-        }, {})
-      }
+        }, {}),
+      },
     }),
   )
   .withHandler(SetLanguage.TYPE, (state, language) => setWith(state, { language }))


### PR DESCRIPTION
Updates `requiresPayment` selector to `false` if no main Stripe key is set.

I removed my main Stripe key in my local dev config table to test. It removed the payment section as expected, but caused this error in the console:

![Screen Shot 2020-07-30 at 8 26 26 AM](https://user-images.githubusercontent.com/1165936/88942065-9ce0b980-d23e-11ea-8132-af21015668ca.png)

I could use some pointers how to bypass Stripe setup if the main Stripe key isn't set to prevent this error