### PR TITLE
[Categories] inventory categories table + display in Products Page

### DIFF
--- a/src/api-services/airtableHelper.js
+++ b/src/api-services/airtableHelper.js
@@ -8,6 +8,7 @@ let Airtable = require('airtable');
 const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(process.env.AIRTABLE_BASE_ID);
 
 export const DEFAULT_VIEW = 'Grid view';
+export const NO_CATEGORY = 'no_category';
 
 export const airTableRowsAsKey = function(records) {
   const rowFields = records.map((row) => {

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -73,3 +73,5 @@ export function byName() {
   });
   return results;
 }
+
+export const NO_CATEGORY = 'no_category';

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -40,6 +40,7 @@ export interface InventoryRecord {
   id: string;
   name: string;
   description: string;
+  category: string;
   strings?: Record<string, InventoryStrings>;
   price: number;
   image: AirtableImage[];
@@ -49,6 +50,24 @@ export interface InventoryRecord {
   stockZipcodes?: string[];
   locations?: IStockLocation[];
   zipcodes?: IStockZipcodes[];
+}
+
+export interface CategoryStrings {
+  category: string;
+  description: string;
+}
+
+export interface IInventoryCategory {
+  id: string;
+  strings: Record<string, CategoryStrings>;
+  inventory: String[];
+}
+
+export interface CategoryRecord {
+  id: string;
+  name: string;
+  description: string;
+  inventory: InventoryRecord[];
 }
 
 export interface AirtableImage {

--- a/src/components/CategoryHeader.module.scss
+++ b/src/components/CategoryHeader.module.scss
@@ -1,0 +1,23 @@
+@import '../common/variables';
+
+.centered {
+  text-align: center;
+}
+
+.container {
+  margin-bottom: spacing(6);
+  padding-bottom: spacing(4);
+
+  .header {
+    margin-bottom: spacing(1);
+  }
+
+  p {
+    margin: 0;
+  }
+}
+
+.container.small {
+  margin-bottom: spacing(3);
+  padding-bottom: 0;
+}

--- a/src/components/CategoryHeader.tsx
+++ b/src/components/CategoryHeader.tsx
@@ -1,0 +1,28 @@
+import {Typography} from '@material-ui/core';
+import React from 'react';
+import styles from './CategoryHeader.module.scss';
+import classNames from 'classnames';
+import {useIsSmall} from "../common/hooks";
+
+interface Props {
+  categoryName?: string;
+  description?: string;
+  centered?: boolean;
+}
+
+const CategoryHeader: React.FC<Props> = ({ categoryName, description, centered }) => {
+  const isSmall = useIsSmall();
+
+  return (
+    <div className={classNames(styles.container, centered && styles.centered, isSmall && styles.small)}>
+      <Typography variant="h4" className={styles.header}>
+        { categoryName }
+      </Typography>
+      <p className={styles.description}>
+        { description }
+      </p>
+    </div>
+  );
+};
+
+export default CategoryHeader;

--- a/src/pages/ProductsPage.tsx
+++ b/src/pages/ProductsPage.tsx
@@ -1,4 +1,4 @@
-import { productListSelector, useContent } from '../store/cms';
+import {productByCategorySelector, productListSelector, useContent} from '../store/cms';
 import { useIsSmall } from '../common/hooks';
 import { useSelector } from 'react-redux';
 import BaseLayout from '../layouts/BaseLayout';
@@ -7,16 +7,20 @@ import ProductSummary from '../components/ProductSummary';
 import React from 'react';
 import classNames from 'classnames';
 import styles from './ProductsPage.module.scss';
+import CategoryHeader from "../components/CategoryHeader";
+import {InventoryRecord} from "../common/types";
 
 const ProductsPage: React.FC = () => {
   const productList = useSelector(productListSelector);
+  const productByCategoryList = useSelector(productByCategorySelector);
   const isSmall = useIsSmall();
   const title = useContent('products_page_title');
   const description = useContent('products_page_subtitle');
   const renderSummaries = productList.length > 4;
+  const renderByCategory = Object.keys(productByCategoryList).length > 1;
 
-  return (
-    <BaseLayout title={title} description={description}>
+  const productListItems = (productList : InventoryRecord[]) => {
+    return (
       <div className={classNames(styles.container, { [styles.summary]: renderSummaries, [styles.small]: isSmall })}>
         {productList.map((item) =>
           renderSummaries ? (
@@ -25,6 +29,32 @@ const ProductsPage: React.FC = () => {
             <ProductDetail key={item.id} product={item} className={styles.productDetail} card={true} />
           ),
         )}
+      </div>
+    )
+  }
+
+  if (renderByCategory) {
+    return (
+      <BaseLayout title={title} description={description}>
+        {productByCategoryList.map((categoryRecord) => (
+          <div>
+            <CategoryHeader
+              key={categoryRecord.id}
+              categoryName={categoryRecord.name}
+              description={categoryRecord.description}
+              centered={renderSummaries}
+            />
+            {productListItems(categoryRecord.inventory)}
+          </div>
+        ))}
+      </BaseLayout>
+    )
+  }
+
+  return (
+    <BaseLayout title={title} description={description}>
+      <div className={classNames(styles.container, { [styles.summary]: renderSummaries, [styles.small]: isSmall })}>
+        {productListItems(productList)}
       </div>
     </BaseLayout>
   );

--- a/src/services/AirtableService.ts
+++ b/src/services/AirtableService.ts
@@ -2,6 +2,7 @@ import { CompoundAction } from 'redoodle';
 import { IAppState } from '../store/app';
 import { IDonationIntent, IOrderIntent, OrderType } from '../common/types';
 import {
+  SetCategories,
   SetConfig,
   SetContent,
   SetInventory,
@@ -38,6 +39,7 @@ export class AirtableService {
         const deliveryEnabled = records.config.delivery_enabled === 'false' ? false : true;
 
         const actions: any = [
+          SetCategories.create(records.categories),
           SetConfig.create({
             languages: records.config.languages.split(','),
             taxRate: records.config.tax_rate,


### PR DESCRIPTION
Airtable:

- [x] Will go through each Airtable and add a **Inventory Categories** table DONE

- Empty tables and inventory not categorized (not linked to Inventory Categories field) shouldn't break existing functionality

ProductByCategorySelector
- Created a new selector that gives a list of CategoryRecord[] with id, translated name, translated description, and a list of products InventoryRecord[]
- If a product/item doesn't have a category, a dummy "NO_CATEGORY" CategoryRecord will be in the selector

Frontend:
- Create a simple `CategoryHeader` to display (title + description)
- If it's rendering with summaries, then the header is left aligned
- If it's rendering without summaries, then the header is center aligned (since the grid product items are centered)

Storefront demo, no summaries:
<img width="1919" alt="storefront_demo_grid" src="https://user-images.githubusercontent.com/1899280/92494709-e52eb800-f1aa-11ea-8bb7-c0f20fd90b75.png">

Storefront demo, with summaries:
<img width="1919" alt="storefront_demo_list" src="https://user-images.githubusercontent.com/1899280/92494726-ec55c600-f1aa-11ea-8943-dac8e9cb38b1.png">

new base with empty Categories table:
<img width="1913" alt="existing_site" src="https://user-images.githubusercontent.com/1899280/92494764-f8418800-f1aa-11ea-8f97-d54d0ec65aa1.png">


