### PR TITLE
Update FE to handle multiple discount codes

### DIFF
--- a/src/api/check-discount-code.js
+++ b/src/api/check-discount-code.js
@@ -101,7 +101,7 @@ exports.handler = async (event, context) => {
 
     return successResponse({
       id: matchedCode.id,
-      code: validSequentialCode ? code : matchedCode['Code'],
+      code: validSequentialCode ? String(code) : matchedCode['Code'],
       amount: matchedCode['Amount'],
       type: matchedCode['Type']
     });

--- a/src/api/create-order.js
+++ b/src/api/create-order.js
@@ -119,7 +119,7 @@ exports.handler = async (event, context) => {
     );
 
     // add discount codes to used sequential codes
-    if (orderIntent.discountCodes) {
+    if (configRecordsByKey?.sequential_discount_code?.value && orderIntent.discountCodes.length > 0) {
       await base('Used Sequential Codes').create(orderIntent.discountCodes.map(code => ({ fields: { Code: code, Order: [order.id] } })));
     }
 

--- a/src/api/create-order.js
+++ b/src/api/create-order.js
@@ -111,9 +111,7 @@ exports.handler = async (event, context) => {
         Tax: orderIntent.tax,
         Tip: orderIntent.tip,
         Total: orderIntent.total,
-        'Discount Code': orderIntent.discountCodes
-          ? orderIntent.discountCodes.join(',')
-          : orderIntent.discountCode,
+        'Discount Code': orderIntent.discountCodes.join(','),
         'Opt In Comms': orderIntent.optInComms,
         'Opt In Subsidy': orderIntent.optInSubsidy,
       },

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -24,6 +24,7 @@ export interface IConfig {
   stripeAPIKeyMain?: string;
   stripeAPIKeyDonation?: string;
   tippingEnabled: boolean;
+  sequentialDiscountCode?: string;
 }
 
 export interface IContentRecord extends Record<string, string | AirtableImage[]> {
@@ -171,7 +172,7 @@ export interface IOrderIntent extends ICheckoutFormData {
   total: number;
   items: IOrderItem[];
   subsidized: boolean;
-  discountCode?: string;
+  discountCodes: string[];
   stripePaymentId?: string;
 }
 

--- a/src/components/DiscountCode.tsx
+++ b/src/components/DiscountCode.tsx
@@ -28,7 +28,9 @@ const DiscountCode: React.FC<Props> = ({ className }) => {
   async function onSubmit() {
     setLoading(true);
 
-    if (!discountCodes.map((discountCode: IDiscountCode) => discountCode.code).includes(code)) {
+    if (discountCodes.map((discountCode: IDiscountCode) => discountCode.code).includes(code)) {
+      setError('Code already used, please try another.');
+    } else {
       const discountCode = await AirtableService.checkDiscountCode(code);
 
       if (discountCode) {
@@ -43,8 +45,6 @@ const DiscountCode: React.FC<Props> = ({ className }) => {
       } else {
         setError('Invalid code, please try again.');
       }
-    } else {
-      setError('Code already used, please try another.');
     }
 
     setLoading(false);

--- a/src/components/DiscountCode.tsx
+++ b/src/components/DiscountCode.tsx
@@ -27,19 +27,24 @@ const DiscountCode: React.FC<Props> = ({ className }) => {
 
   async function onSubmit() {
     setLoading(true);
-    const discountCode = await AirtableService.checkDiscountCode(code);
 
-    if (discountCode) {
-      // If this is a sequential discount code, allow multiple entries by adding to discountCodes array
-      if (sequentialDiscountCode) {
-        dispatch(SetDiscountCodeMultiple.create(discountCode));
+    if (!discountCodes.map((discountCode: IDiscountCode) => discountCode.code).includes(code)) {
+      const discountCode = await AirtableService.checkDiscountCode(code);
+
+      if (discountCode) {
+        // If this is a sequential discount code, allow multiple entries by adding to discountCodes array
+        if (sequentialDiscountCode) {
+          dispatch(SetDiscountCodeMultiple.create(discountCode));
+        } else {
+          dispatch(SetDiscountCode.create(discountCode));
+        }
+
+        setCode('');
       } else {
-        dispatch(SetDiscountCode.create(discountCode));
+        setError('Invalid code, please try again.');
       }
-
-      setCode('');
     } else {
-      setError('Invalid code, please try again.');
+      setError('Code already used, please try another.');
     }
 
     setLoading(false);

--- a/src/components/OrderSummary.tsx
+++ b/src/components/OrderSummary.tsx
@@ -3,7 +3,6 @@ import { IAppState } from '../store/app';
 import { IConfig, IDiscountCode, IOrderItem, IOrderSummary, InventoryRecord, OrderType } from '../common/types';
 import {
   discountDollarAmountsSelector,
-  discountTotalSelector,
   itemsSelector,
   subtotalSelector,
   taxSelector,
@@ -36,7 +35,6 @@ const OrderSummary: React.FC<Props> = ({ className, showLineItems, editable, ord
   const isDonationRequest = useSelector<IAppState, boolean>((state) => state.checkout.isDonationRequest);
   const subtotal = useSelector<IAppState, number>(subtotalSelector);
   const discountDollarAmounts = useSelector<IAppState, Record<string, number>>(discountDollarAmountsSelector);
-  const discount = useSelector<IAppState, number>(discountTotalSelector);
   const discountCodes = useSelector<IAppState, IDiscountCode[]>((state) => state.checkout.discountCodes);
   const config = useSelector<IAppState, IConfig>((state) => state.cms.config);
   const { taxRate, tippingEnabled } = config;

--- a/src/components/OrderSummary.tsx
+++ b/src/components/OrderSummary.tsx
@@ -2,7 +2,8 @@ import { Card, Typography } from '@material-ui/core';
 import { IAppState } from '../store/app';
 import { IConfig, IDiscountCode, IOrderItem, IOrderSummary, InventoryRecord, OrderType } from '../common/types';
 import {
-  discountSelector,
+  discountDollarAmountsSelector,
+  discountTotalSelector,
   itemsSelector,
   subtotalSelector,
   taxSelector,
@@ -34,8 +35,9 @@ const OrderSummary: React.FC<Props> = ({ className, showLineItems, editable, ord
   const isSmall = useIsSmall();
   const isDonationRequest = useSelector<IAppState, boolean>((state) => state.checkout.isDonationRequest);
   const subtotal = useSelector<IAppState, number>(subtotalSelector);
-  const discount = useSelector<IAppState, number>(discountSelector);
-  const discountCode = useSelector<IAppState, IDiscountCode | undefined>((state) => state.checkout.discountCode);
+  const discountDollarAmounts = useSelector<IAppState, Record<string, number>>(discountDollarAmountsSelector);
+  const discount = useSelector<IAppState, number>(discountTotalSelector);
+  const discountCodes = useSelector<IAppState, IDiscountCode[]>((state) => state.checkout.discountCodes);
   const config = useSelector<IAppState, IConfig>((state) => state.cms.config);
   const { taxRate, tippingEnabled } = config;
   const tipPercentage = useSelector<IAppState, number>((state) => state.checkout.tipPercentage);
@@ -97,16 +99,26 @@ const OrderSummary: React.FC<Props> = ({ className, showLineItems, editable, ord
             </Typography>
           </div>
         )}
-        {(!!orderSummary?.discount || !!discount) && (
+        {orderSummary?.discount ? (
           <div className={styles.line}>
             <Typography variant="body1" className={styles.label}>
-              <Content id="order_summary_discount" defaultText="Discount" />{' '}
-              {discountCode && `(${formatDiscountCode(discountCode)})`}
+              Discounts
             </Typography>
             <Typography variant="body1" className={styles.value}>
-              -{formatCurrency(orderSummary?.discount || discount)}
+              -{formatCurrency(orderSummary?.discount)}
             </Typography>
           </div>
+        ) : (
+          discountCodes.map((discountCode, index) => (
+            <div key={`${index}-${discountCode}`} className={styles.line}>
+              <Typography variant="body1" className={styles.label}>
+                {discountCode.code} {discountCode && `(${formatDiscountCode(discountCode)})`}
+              </Typography>
+              <Typography variant="body1" className={styles.value}>
+                -{formatCurrency(discountDollarAmounts[discountCode.code])}
+              </Typography>
+            </div>
+          ))
         )}
         {isDelivery && (
           <div className={styles.line}>

--- a/src/services/AirtableService.ts
+++ b/src/services/AirtableService.ts
@@ -66,6 +66,7 @@ export class AirtableService {
             stripeAPIKeyMain: records.config.stripe_main_public_api_key,
             stripeAPIKeyDonation: records.config.stripe_donation_public_api_key,
             tippingEnabled: records.config.tipping_enabled === 'true' ? true : false,
+            sequentialDiscountCode: records.config.sequential_discount_code,
           }),
           SetOrderType.create(
             deliveryEnabled ? records.config.default_order_type || OrderType.DELIVERY : OrderType.PICKUP,

--- a/src/services/StripeService.ts
+++ b/src/services/StripeService.ts
@@ -14,6 +14,7 @@ import {
 import {
   SetConfirmation,
   SetDiscountCode,
+  SetDiscountCodeMultiple,
   SetError,
   SetIsPaying,
   SetWaitlistDialogIsOpen,
@@ -21,7 +22,7 @@ import {
 } from '../store/checkout';
 import {
   SetItems,
-  discountSelector,
+  discountTotalSelector,
   itemsSelector,
   subtotalSelector,
   taxSelector,
@@ -83,14 +84,14 @@ export class StripeService {
   public static async pay(formData: ICheckoutFormData, stripe: Stripe | null, elements: StripeElements | null) {
     const state = StripeService.store.getState();
     const subtotal = subtotalSelector(state);
-    const discount = discountSelector(state);
+    const discount = discountTotalSelector(state);
     const tax = taxSelector(state);
     const tip = tipSelector(state);
     const total = totalSelector(state);
     const productList = productListSelector(state);
     const requiresPayment = requiresPaymentSelector(state);
     const waitlistConfirmed = state.checkout.waitlistConfirmed;
-    const discountCode = state.checkout.discountCode?.code;
+    const discountCodes = state.checkout.discountCodes.map((discountCode) => discountCode.code);
     const isDonationRequest = state.checkout.isDonationRequest;
     const stockByLocation = state.cms.config.stockByLocation;
     const type = state.cart.orderType;
@@ -106,7 +107,7 @@ export class StripeService {
       tax,
       tip,
       total,
-      discountCode,
+      discountCodes,
       items,
     };
 
@@ -159,6 +160,7 @@ export class StripeService {
           SetIsPaying.create(false),
           SetItems.create([]),
           SetDiscountCode.create(undefined),
+          SetDiscountCodeMultiple.create(undefined),
         ]),
       );
       return PaymentStatus.SUCCEEDED;

--- a/src/store/cart.ts
+++ b/src/store/cart.ts
@@ -133,7 +133,6 @@ export const subtotalWithDiscountSelector = Reselect.createSelector(
   subtotalSelector,
   discountTotalSelector,
   (subtotal: number, discountTotal: number) => {
-    console.log(discountTotal);
     return Math.max(subtotal - discountTotal, 0);
   },
 );

--- a/src/store/cart.ts
+++ b/src/store/cart.ts
@@ -106,23 +106,35 @@ export const subtotalSelector = Reselect.createSelector(
   },
 );
 
-export const discountSelector = Reselect.createSelector(
+const getDiscountDollarAmount = (subtotal: number, discountCode: IDiscountCode) =>
+  discountCode.type === DiscountCodeType.DOLLARS ? discountCode.amount : subtotal * (discountCode.amount / 100);
+
+export const discountDollarAmountsSelector = Reselect.createSelector(
   subtotalSelector,
-  (state: IAppState) => state.checkout.discountCode,
-  (subtotal: number, discountCode?: IDiscountCode) => {
-    return !discountCode
-      ? 0
-      : discountCode.type === DiscountCodeType.DOLLARS
-      ? discountCode.amount
-      : subtotal * (discountCode.amount / 100);
-  },
+  (state: IAppState) => state.checkout.discountCodes,
+  (subtotal: number, discountCodes: IDiscountCode[]) =>
+    discountCodes.reduce((discountAmounts: Record<string, number>, discountCode: IDiscountCode) => {
+      discountAmounts[discountCode.code] = getDiscountDollarAmount(subtotal, discountCode);
+      return discountAmounts;
+    }, {}),
+);
+
+export const discountTotalSelector = Reselect.createSelector(
+  subtotalSelector,
+  (state: IAppState) => state.checkout.discountCodes,
+  (subtotal: number, discountCodes: IDiscountCode[]) =>
+    discountCodes.reduce(
+      (total: number, discountCode: IDiscountCode) => total + getDiscountDollarAmount(subtotal, discountCode),
+      0,
+    ),
 );
 
 export const subtotalWithDiscountSelector = Reselect.createSelector(
   subtotalSelector,
-  discountSelector,
-  (subtotal: number, discount: number) => {
-    return Math.max(subtotal - discount, 0);
+  discountTotalSelector,
+  (subtotal: number, discountTotal: number) => {
+    console.log(discountTotal);
+    return Math.max(subtotal - discountTotal, 0);
   },
 );
 

--- a/src/store/checkout.ts
+++ b/src/store/checkout.ts
@@ -52,7 +52,7 @@ export const checkoutReducer: any = TypedReducer.builder<ICheckoutState>()
   .withHandler(SetConfirmation.TYPE, (state, confirmation) => setWith(state, { confirmation }))
   .withHandler(SetDiscountCode.TYPE, (state, discountCode) => {
     if (discountCode) {
-      // If the discount is not "stackable" (i.e. multiple codes are not allowed) we just replace whatever is in discountCodes
+      // If multiple codes are not allowed, we just replace whatever is in discountCodes
       return setWith(state, { discountCodes: [discountCode] });
     }
 


### PR DESCRIPTION
[Work in progress]

Changes `discountCode` in checkoutState to always be an array. If multiple discounts are allowed, array contains multiple items. Otherwise the first value is always overridden