### PR TITLE
If single category cart enabled, disable Add To Cart button if item i…

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -15,6 +15,7 @@ export interface IConfig {
   deliveryPreferences: boolean;
   deliveryOptionsOnCheckout: boolean;
   cartEnabled: boolean;
+  singleCategoryCartEnabled: boolean;
   payUponPickupEnabled: boolean;
   payUponDeliveryEnabled: boolean;
   embeddedViewEnabled: boolean;
@@ -106,6 +107,7 @@ export interface IOrderItem {
   id: string;
   quantity: number;
   addOn?: boolean;
+  category?: string;
 }
 
 export interface IAddress {

--- a/src/components/ProductDetail.tsx
+++ b/src/components/ProductDetail.tsx
@@ -3,7 +3,6 @@ import { Button, Card, Chip, Grid, Select, Tooltip, Typography } from '@material
 import { CompoundAction } from 'redoodle';
 import { IAppState } from '../store/app';
 import { IConfig, IOrderItem, InventoryRecord } from '../common/types';
-import { NO_CATEGORY } from '../common/constants';
 import { SetIsDonationRequest } from '../store/checkout';
 import { formatCurrency } from '../common/format';
 import { getImageUrl } from '../common/utils';

--- a/src/components/ProductDetail.tsx
+++ b/src/components/ProductDetail.tsx
@@ -1,12 +1,14 @@
-import { AddItem, IOrderItemCountSelector, SetDialogIsOpen, SetItems } from '../store/cart';
+import { AddItem, IOrderItemCountSelector, SetDialogIsOpen, SetItems, itemsSelector } from '../store/cart';
 import { Button, Card, Chip, Grid, Select, Tooltip, Typography } from '@material-ui/core';
 import { CompoundAction } from 'redoodle';
 import { IAppState } from '../store/app';
-import { IConfig, InventoryRecord } from '../common/types';
+import { IConfig, IOrderItem, InventoryRecord } from '../common/types';
+import { NO_CATEGORY } from '../common/constants';
 import { SetIsDonationRequest } from '../store/checkout';
 import { formatCurrency } from '../common/format';
 import { getImageUrl } from '../common/utils';
 import { reverse } from '../common/router';
+import { useContent } from '../store/cms';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { useIsSmall } from '../common/hooks';
@@ -26,16 +28,18 @@ const ProductDetail: React.FC<Props> = ({ card, product, className }) => {
   const [short, setShort] = useState<boolean>(true);
   const [quantity, setQuantity] = useState<number>(1);
   const dispatch = useDispatch();
-  const { id, name, description, price, locations, addOn } = product;
+  const { id, category, name, description, price, locations, addOn } = product;
   const history = useHistory();
   const config = useSelector<IAppState, IConfig>((state) => state.cms.config);
-  const { paymentEnabled, waitlistEnabled, stockByLocation } = config;
+  const { paymentEnabled, waitlistEnabled, stockByLocation, singleCategoryCartEnabled } = config;
   const orderItemCount = useSelector<IAppState, number>(IOrderItemCountSelector);
+  const cartItems = useSelector<IAppState, IOrderItem[]>(itemsSelector);
+  const contentDisabledHelpText = useContent('disabled_add_cart_help_text');
 
   function addToCart() {
     dispatch(
       CompoundAction([
-        AddItem.create({ addOn, id, quantity }),
+        AddItem.create({ addOn, category, id, quantity }),
         SetDialogIsOpen.create(true),
         SetIsDonationRequest.create(false),
       ]),
@@ -45,6 +49,25 @@ const ProductDetail: React.FC<Props> = ({ card, product, className }) => {
   function addToWaitlist() {
     dispatch(CompoundAction([SetItems.create([{ id, quantity: 1 }]), SetIsDonationRequest.create(true)]));
     history.push(reverse('checkout', { waitlist: true }));
+  }
+
+  const addOnShouldDisable = orderItemCount === 0 && addOn;
+
+  // If single category cart is enabled, we disable the Add to Cart button if the item's category
+  // doesn't match the category of the first item in the cart
+  const singleCategoryShouldDisable =
+    singleCategoryCartEnabled &&
+    orderItemCount > 0 &&
+    // Either category is the string 'no_category', an empty array, or array with a single item
+    category.toString() !== (cartItems[0].category && cartItems[0].category.toString());
+
+  const shouldDisableAddToChart = addOnShouldDisable || singleCategoryShouldDisable;
+
+  let disabledHelpText = '';
+  if (addOnShouldDisable) {
+    disabledHelpText = 'This is an add-on item. Add another item to your cart to include this item';
+  } else if (singleCategoryShouldDisable) {
+    disabledHelpText = contentDisabledHelpText || 'You can only add items from a single category';
   }
 
   return (
@@ -91,7 +114,7 @@ const ProductDetail: React.FC<Props> = ({ card, product, className }) => {
                   value={quantity}
                   inputProps={{ name: 'quantity' }}
                   onChange={(e: ChangeEvent<any>) => setQuantity(parseInt(e.target.value))}
-                  disabled={addOn && orderItemCount === 0}
+                  disabled={shouldDisableAddToChart}
                 >
                   {[1, 2, 3, 4, 5, 6, 7, 8].map((q) => (
                     <option key={q} value={q}>
@@ -100,13 +123,7 @@ const ProductDetail: React.FC<Props> = ({ card, product, className }) => {
                   ))}
                 </Select>
               </div>
-              <Tooltip
-                title={
-                  addOn && orderItemCount === 0
-                    ? 'This is an add-on item. Add another item to your cart to include this item'
-                    : ''
-                }
-              >
+              <Tooltip title={disabledHelpText}>
                 <span>
                   {/* Tooltips don't appear if their immediate child is disabled, so this is wrapped in a <span> as buffer */}
                   <Button
@@ -115,7 +132,7 @@ const ProductDetail: React.FC<Props> = ({ card, product, className }) => {
                     color="primary"
                     size="large"
                     onClick={addToCart}
-                    disabled={addOn && orderItemCount === 0}
+                    disabled={shouldDisableAddToChart}
                   >
                     <Content id="products_purchase_button_label" />
                   </Button>

--- a/src/services/AirtableService.ts
+++ b/src/services/AirtableService.ts
@@ -57,6 +57,7 @@ export class AirtableService {
             deliveryPreferences: records.config.delivery_preferences === 'false' ? false : true,
             deliveryOptionsOnCheckout: records.config.delivery_options_on_checkout === 'true' ? true : false,
             cartEnabled: records.config.cart_enabled === 'false' ? false : true,
+            singleCategoryCartEnabled: records.config.single_category_cart_enabled === 'false' ? false : true,
             payUponPickupEnabled: records.config.pay_upon_pickup_enabled === 'false' ? false : true,
             payUponDeliveryEnabled: records.config.pay_upon_pickup_enabled === 'true' ? true : false,
             embeddedViewEnabled: records.config.embedded_view_enabled === 'false' ? false : true,

--- a/src/store/cms.ts
+++ b/src/store/cms.ts
@@ -95,6 +95,7 @@ export const initialCmsState: ICmsState = {
     deliveryPreferences: true,
     deliveryOptionsOnCheckout: false,
     cartEnabled: true,
+    singleCategoryCartEnabled: false,
     payUponPickupEnabled: true,
     payUponDeliveryEnabled: false,
     embeddedViewEnabled: true,


### PR DESCRIPTION
…sn't in same category as cart items

Adds a new configuration option `single_category_cart_enabled`; when enabled disables the Add To Cart button on the product detail page if the item is not in the same category as whatever is in the cart

Also adds content key `disabled_add_cart_help_text` so partners can change the help text that appears for the disabled Add to Cart button (currently defaults to "You can only add items from a single category"