### PR TITLE
Delivery Fee

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -14,6 +14,7 @@ export interface IConfig {
   deliveryEnabled: boolean;
   deliveryPreferences: boolean;
   deliveryOptionsOnCheckout: boolean;
+  deliveryFee: number;
   cartEnabled: boolean;
   singleCategoryCartEnabled: boolean;
   payUponPickupEnabled: boolean;

--- a/src/components/OrderSummary.tsx
+++ b/src/components/OrderSummary.tsx
@@ -37,7 +37,7 @@ const OrderSummary: React.FC<Props> = ({ className, showLineItems, editable, ord
   const discountDollarAmounts = useSelector<IAppState, Record<string, number>>(discountDollarAmountsSelector);
   const discountCodes = useSelector<IAppState, IDiscountCode[]>((state) => state.checkout.discountCodes);
   const config = useSelector<IAppState, IConfig>((state) => state.cms.config);
-  const { taxRate, tippingEnabled } = config;
+  const { taxRate, tippingEnabled, deliveryFee } = config;
   const tipPercentage = useSelector<IAppState, number>((state) => state.checkout.tipPercentage);
   const tax = useSelector<IAppState, number>(taxSelector);
   const tip = useSelector<IAppState, number>(tipSelector);
@@ -124,7 +124,11 @@ const OrderSummary: React.FC<Props> = ({ className, showLineItems, editable, ord
               <Content id="order_summary_delivery_fee" defaultText="Delivery Fee" />
             </Typography>
             <Typography variant="body1" className={styles.value}>
-              <Content id="order_summary_delivery_fee_free" defaultText="FREE" />
+              {deliveryFee > 0 ? (
+                formatCurrency(deliveryFee)
+              ) : (
+                <Content id="order_summary_delivery_fee_free" defaultText="FREE" />
+              )}
             </Typography>
           </div>
         )}

--- a/src/services/AirtableService.ts
+++ b/src/services/AirtableService.ts
@@ -57,7 +57,7 @@ export class AirtableService {
             deliveryPreferences: records.config.delivery_preferences === 'false' ? false : true,
             deliveryOptionsOnCheckout: records.config.delivery_options_on_checkout === 'true' ? true : false,
             cartEnabled: records.config.cart_enabled === 'false' ? false : true,
-            singleCategoryCartEnabled: records.config.single_category_cart_enabled === 'false' ? false : true,
+            singleCategoryCartEnabled: records.config.single_category_cart_enabled === 'true' ? true : false,
             payUponPickupEnabled: records.config.pay_upon_pickup_enabled === 'false' ? false : true,
             payUponDeliveryEnabled: records.config.pay_upon_pickup_enabled === 'true' ? true : false,
             embeddedViewEnabled: records.config.embedded_view_enabled === 'false' ? false : true,

--- a/src/services/AirtableService.ts
+++ b/src/services/AirtableService.ts
@@ -42,7 +42,7 @@ export class AirtableService {
           SetCategories.create(records.categories),
           SetConfig.create({
             languages: records.config.languages.split(','),
-            taxRate: records.config.tax_rate,
+            taxRate: records.config.tax_rate ? parseFloat(records.config.tax_rate) : 0,
             projectName: records.config.project_name,
             defaultState: records.config.default_state,
             themeColor: records.config.theme_color,
@@ -56,6 +56,7 @@ export class AirtableService {
             deliveryEnabled: deliveryEnabled,
             deliveryPreferences: records.config.delivery_preferences === 'false' ? false : true,
             deliveryOptionsOnCheckout: records.config.delivery_options_on_checkout === 'true' ? true : false,
+            deliveryFee: records.config.delivery_fee ? parseFloat(records.config.delivery_fee) : 0,
             cartEnabled: records.config.cart_enabled === 'false' ? false : true,
             singleCategoryCartEnabled: records.config.single_category_cart_enabled === 'true' ? true : false,
             payUponPickupEnabled: records.config.pay_upon_pickup_enabled === 'false' ? false : true,

--- a/src/store/cart.ts
+++ b/src/store/cart.ts
@@ -162,7 +162,6 @@ export const totalSelector = Reselect.createSelector(
   (state: IAppState) => state.cms.config.deliveryFee,
   (state: IAppState) => state.cart.orderType,
   (subtotal: number, tax: number, tip: number, deliveryFee: number, orderType: OrderType) => {
-    console.log('total', subtotal + tip + tax + (orderType === OrderType.DELIVERY ? deliveryFee : 0));
     return subtotal + tip + tax + (orderType === OrderType.DELIVERY ? deliveryFee : 0);
   },
 );

--- a/src/store/cart.ts
+++ b/src/store/cart.ts
@@ -159,8 +159,11 @@ export const totalSelector = Reselect.createSelector(
   subtotalWithDiscountSelector,
   taxSelector,
   tipSelector,
-  (subtotal: number, tax: number, tip: number) => {
-    return subtotal + tip + tax;
+  (state: IAppState) => state.cms.config.deliveryFee,
+  (state: IAppState) => state.cart.orderType,
+  (subtotal: number, tax: number, tip: number, deliveryFee: number, orderType: OrderType) => {
+    console.log('total', subtotal + tip + tax + (orderType === OrderType.DELIVERY ? deliveryFee : 0));
+    return subtotal + tip + tax + (orderType === OrderType.DELIVERY ? deliveryFee : 0);
   },
 );
 

--- a/src/store/cms.ts
+++ b/src/store/cms.ts
@@ -94,6 +94,7 @@ export const initialCmsState: ICmsState = {
     deliveryEnabled: true,
     deliveryPreferences: true,
     deliveryOptionsOnCheckout: false,
+    deliveryFee: 0,
     cartEnabled: true,
     singleCategoryCartEnabled: false,
     payUponPickupEnabled: true,


### PR DESCRIPTION
* added support for delivery fee

Airtable Schema Changes:
* `delivery_fee key` to Config table (default blank, can be a number with decimal, e.g. 3.99)