### PR TITLE
Add anchor links for category headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/react-dom": "^16.9.0",
     "@types/react-redux": "^7.1.7",
     "@types/redux": "^3.6.0",
+    "@types/slug": "^0.9.1",
     "@typescript-eslint/eslint-plugin": "^2.15.0",
     "@typescript-eslint/parser": "^2.15.0",
     "airtable": "^0.8.1",
@@ -60,6 +61,7 @@
     "redux-persist": "^6.0.0",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
+    "slug": "^4.0.2",
     "stripe": "^8.47.0",
     "typeface-inter": "^3.12.0",
     "typescript": "~3.7.2"

--- a/src/components/CategoryHeader.module.scss
+++ b/src/components/CategoryHeader.module.scss
@@ -5,6 +5,7 @@
 }
 
 .container {
+  position: relative;
   margin-bottom: spacing(6);
   padding-bottom: spacing(4);
 
@@ -15,6 +16,12 @@
   p {
     margin: 0;
   }
+}
+
+.anchor {
+  position: absolute;
+  visibility: hidden;
+  top: -100px;
 }
 
 .container.small {

--- a/src/components/CategoryHeader.tsx
+++ b/src/components/CategoryHeader.tsx
@@ -2,6 +2,7 @@ import { Typography } from '@material-ui/core';
 import { useIsSmall } from '../common/hooks';
 import React from 'react';
 import classNames from 'classnames';
+import slug from 'slug';
 import styles from './CategoryHeader.module.scss';
 
 interface Props {
@@ -15,6 +16,9 @@ const CategoryHeader: React.FC<Props> = ({ categoryName, description, centered }
 
   return (
     <div className={classNames(styles.container, centered && styles.centered, isSmall && styles.small)}>
+      {/* Using a hidden div positioned higher up on the page as the navigation location for URL fragments,
+      as navigating directly to the header causes it to be hidden by the sticky navigation bar */}
+      {categoryName && <div className={styles.anchor} id={slug(categoryName)}></div>}
       <Typography variant="h4" className={styles.header}>
         {categoryName}
       </Typography>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1843,6 +1843,11 @@
   dependencies:
     redux "*"
 
+"@types/slug@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@types/slug/-/slug-0.9.1.tgz#16dbf8b77d73e0a09ce51a96400878f33806ab32"
+  integrity sha512-zR/u8WFQ4/6uCIikjI00a5uB084XjgEGNRAvM4a1BL39Bw9yEiDQFiPS2DgJ8lPDkR2Qd/vZ26dCR9XqlKbDqQ==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -11023,6 +11028,11 @@ slice-ansi@^2.1.0:
     ansi-styles "^3.2.0"
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
+
+slug@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/slug/-/slug-4.0.2.tgz#35a62b4e71582778ac08bb30a1bf439fd0a43ea7"
+  integrity sha512-c5XbWkwxHU13gAdSvBHQgnGy2sxv/REMz0ugcM0SOSBCO/N4wfU0TDBC3pgdOwVGjZwGnLBTRljXzdVYE+KYNw==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
Adds a hidden div with id of category header slug so you can linked directly to them. Uses `slug` (https://github.com/Trott/slug) to turn category names like `Produce Boxes` into `produce-boxes`.

Tested by adding a random link with `href="/products#fruit-boxes"` and verified page loads with Fruit Boxes at top of page