### PR TITLE
Fix for category inventory item "undefined" error

### DIFF
--- a/src/store/cms.ts
+++ b/src/store/cms.ts
@@ -221,7 +221,8 @@ export const productByCategorySelector = Reselect.createSelector(
           name: category.strings[language].category,
           description: category.strings[language].description,
           inventory: category.inventory
-            // productsById[productId.toString() is occasionally undefined
+            // There seems to be cases where categories inventory contains a productId that's not in our products list,
+            // resulting in productsById[productId.toString() being undefined. This filters those out
             .filter((productId) => productsById[productId.toString()])
             .map((productId) => productsById[productId.toString()]),
         });

--- a/src/store/cms.ts
+++ b/src/store/cms.ts
@@ -220,7 +220,10 @@ export const productByCategorySelector = Reselect.createSelector(
           id: category.id,
           name: category.strings[language].category,
           description: category.strings[language].description,
-          inventory: category.inventory.map((productId) => productsById[productId.toString()]),
+          inventory: category.inventory
+            // productsById[productId.toString() is occasionally undefined
+            .filter((productId) => productsById[productId.toString()])
+            .map((productId) => productsById[productId.toString()]),
         });
       }
     });


### PR DESCRIPTION
Not sure why but it seemed like there was a mismatch between what the category records had as their inventory ids, and the inventory ids we have stored in the app. This would lead to an "undefined" item in the end list that we use for the product page.

This checks that `productsById[productId.toString()]` actually exists before we add it to the category inventory list